### PR TITLE
fix(website): sorting of PAKT names in accordeon is now case insensit…

### DIFF
--- a/apps/website/src/pages/pakt.tsx
+++ b/apps/website/src/pages/pakt.tsx
@@ -124,7 +124,7 @@ export default Pakt;
 export const pageQuery = graphql`
   query PaktPage {
     paktData: allMarkdownRemark(
-      sort: { fields: [frontmatter___category, frontmatter___name], order: ASC }
+      sort: { fields: [frontmatter___category, frontmatter___slug], order: ASC }
     ) {
       edges {
         node {


### PR DESCRIPTION
- PAKT name sorting is now case insensitive (sort by slug)

Closes #309